### PR TITLE
Add umode +S for services

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,7 +4,6 @@ Copyright (c) 2001-2002 ircd-hybrid development team
 Copyright (c) 2002-2015 ircd-ratbox development team
 
 $Id$
-[cs_akick_check](https://modules.anope.org/index.php?page=view&id=288 "View module on the Anope Module Site")
  __               __                 __   __
 |__|.----.----.--|  |___.----.---.-.|  |_|  |--.-----.--.--.
 |  ||   _|  __|  _  |___|   _|  _  ||   _|  _  |  _  |_   _|

--- a/INSTALL
+++ b/INSTALL
@@ -4,6 +4,7 @@ Copyright (c) 2001-2002 ircd-hybrid development team
 Copyright (c) 2002-2015 ircd-ratbox development team
 
 $Id$
+[cs_akick_check](https://modules.anope.org/index.php?page=view&id=288 "View module on the Anope Module Site")
  __               __                 __   __
 |__|.----.----.--|  |___.----.---.-.|  |_|  |--.-----.--.--.
 |  ||   _|  __|  _  |___|   _|  _  ||   _|  _  |  _  |_   _|

--- a/doc/modes.txt
+++ b/doc/modes.txt
@@ -23,6 +23,7 @@ User Modes:
 +y - spy        - See LINKS, STATS (if configured), TRACE notices
 +z - operwall   - See oper generated WALLOPS
 +D - deaf       - Ignore all PRIVMSG's sent to channels
++S - Service    - Makes IRC Services unkickable
 +Z - operspy    - See operspy notices
 
 Channel Modes:

--- a/help/opers/umode
+++ b/help/opers/umode
@@ -26,3 +26,4 @@ Usermodes: (* designates that the umode is oper only)
        * +z     - Can see oper wallops.
        * +Z     - Can see operspy notices
          +D     - Deaf - ignores all channel messages.
+       * +S     - Service - Makes IRC Services unkickable


### PR DESCRIPTION
It appears the umode +S making services unkickable (it is not stated whether they can also not be deoped) has been missing, most likely due to services support needing to be compiled in.

Regards,

Koragg